### PR TITLE
Remove return false on 404 response

### DIFF
--- a/src/Etsy.php
+++ b/src/Etsy.php
@@ -215,9 +215,7 @@ class Etsy {
       $response = $e->getResponse();
       $body = $response->getBody();
       $status_code = $response->getStatusCode();
-      if($status_code == 404) {
-        return false;
-      }
+      
       throw new \Exception("Request error. Status code: {$status_code}. Error: {$body}.");
     }
     return $response;


### PR DESCRIPTION
Hi Rhys, thanks for setting up the wrapper. It's currently serving me well to create listings on Etsy! 

I'm proposing to drop the return false on a 404 response. 
I was trying to create a listing with a wrong shipping_template_id, and instead of getting an error "404: Shipping template id is not found. I didn't got any error back regarding the Shipping template. 

Removing this got me the error message in Laravel I was looking for. 

Thanks again !