### PR TITLE
Adding parameter array to Listing->getInventory()

### DIFF
--- a/src/Resources/Listing.php
+++ b/src/Resources/Listing.php
@@ -269,11 +269,12 @@ class Listing extends Resource {
    * @link https://developers.etsy.com/documentation/reference#operation/getListingInventory
    * @return Etsy\Resources\ListingInventory
    */
-  public function getInventory() {
+  public function getInventory(array $params = []) {
     $inventory = $this->request(
       "GET",
       "/application/listings/{$this->listing_id}/inventory",
-      "ListingInventory"
+      "ListingInventory",
+      $params
     );
     // Assign the listing ID to associated inventory products.
     array_map(


### PR DESCRIPTION
Etsy's API allows parameters to be passed into getListingInventory. https://developer.etsy.com/documentation/reference#operation/getListingInventory

This updates the code to allow them to be passed, simply copying the way other functions in the file handle the same thing.