### PR TITLE
Bug Fix: Update ListingInventory::get to be a static function

### DIFF
--- a/src/Resources/ListingInventory.php
+++ b/src/Resources/ListingInventory.php
@@ -27,7 +27,7 @@ class ListingInventory extends Resource {
    * @param array @params
    * @return \Etsy\Resources\ListingInventory
    */
-  public function get(
+  public static function get(
     int $listing_id,
     array $params = []
   ): ?\Etsy\Resources\ListingInventory {


### PR DESCRIPTION
`PHP Fatal error:  Uncaught Error: Non-static method Etsy\Resources\ListingInventory::get() cannot be called statically in /vendor/rhysnhall/etsy-php-sdk/src/Resources/Listing.php:516`

When calling the Listing resource's inventory function, an error is thrown because it calls ListingInventory::get() statically, but ListingInventory's 'get' is not a static function. 

When comparing resources, the get function is static in other resources, so this pull request resolves the error by making ListingInventory's get function static, bringing it in line with the rest of the resources.