### PR TITLE
Adding param to Listing->inventory to pass to ListingInventory::get

### DIFF
--- a/src/Resources/Listing.php
+++ b/src/Resources/Listing.php
@@ -512,9 +512,10 @@ class Listing extends Resource {
    * 
    * @return \Etsy\Resources\ListingInventory
    */
-  public function inventory(): ?\Etsy\Resources\ListingInventory {
+  public function inventory(array $params = []): ?\Etsy\Resources\ListingInventory {
     return ListingInventory::get(
-      $this->listing_id
+      $this->listing_id,
+      $params
     );
   }
 


### PR DESCRIPTION
ListingInventory::get() accepts a second parameter, which Listing->inventory() does not pass to it. This commit adds a parameter to Listing->inventory() so that it can pass it into ListingInventory::get().

Note:
The `ListingInventory::get` call throws an error with or without this merge. There is a separate pull request here (#31) to resolve that. 