### PR TITLE
Fix: Handle ConnectException in catch blocks that call getResponse()

### DIFF
--- a/src/OAuth/Client.php
+++ b/src/OAuth/Client.php
@@ -124,6 +124,11 @@ class Client {
       return $response;
     }
     catch(\Exception $e) {
+      if(!method_exists($e, 'getResponse') || !$e->getResponse()) {
+        throw new RequestException(
+          "Request failed: {$e->getMessage()}"
+        );
+      }
       $response = $e->getResponse();
       $body = json_decode($response->getBody(), false);
       $status_code = $response->getStatusCode();
@@ -269,6 +274,11 @@ class Client {
    * @throws Etsy\Exception\OAuthException
    */
   private function handleAcessTokenError(\Exception $e) {
+    if(!method_exists($e, 'getResponse') || !$e->getResponse()) {
+      throw new OAuthException(
+        "OAuth request failed: {$e->getMessage()}"
+      );
+    }
     $response = $e->getResponse();
     $body = json_decode($response->getBody(), false);
     $status_code = $response->getStatusCode();


### PR DESCRIPTION
## Summary
- `GuzzleHttp\Exception\ConnectException` (thrown on network failures like DNS errors or connection timeouts) does not have a `getResponse()` method
- The catch blocks in `__call()` and `handleAcessTokenError()` catch all `\Exception` but call `getResponse()` unconditionally, causing a fatal error when the Etsy API is unreachable
- Added `method_exists()` and null checks before calling `getResponse()`. When no response is available, a descriptive error is thrown with the original exception message

## Reproduction
Any network failure (DNS timeout, connection refused, etc.) when calling the Etsy API triggers:
```
Error: Call to undefined method GuzzleHttp\Exception\ConnectException::getResponse()
in src/OAuth/Client.php:127
```

## Changes
- `src/OAuth/Client.php`: Guard `getResponse()` calls in both `__call()` (API requests) and `handleAcessTokenError()` (OAuth token requests)